### PR TITLE
WIP - openstack: add periodic job for STF 1.3

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-master__nightly-4.8.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-master__nightly-4.8.yaml
@@ -332,6 +332,11 @@ tests:
     - chain: ipi-gcp-pre
     - ref: fips-check
     workflow: openshift-e2e-gcp
+- as: e2e-openstack-stf-1-3
+  interval: 24h
+  steps:
+    cluster_profile: openstack-vexxhost
+    workflow: openshift-e2e-openstack-stf-1-3
 - as: console-aws
   interval: 48h
   steps:

--- a/ci-operator/jobs/openshift/release/openshift-release-release-4.8-periodics.yaml
+++ b/ci-operator/jobs/openshift/release/openshift-release-release-4.8-periodics.yaml
@@ -1814,6 +1814,89 @@ periodics:
 - agent: kubernetes
   cluster: build01
   decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/variant: nightly-4.8
+    ci.openshift.io/generator: prowgen
+    job-release: "4.8"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-nightly-4.8-e2e-openstack-stf-1.3
+  reporter_config:
+    slack:
+      channel: '#forum-stf'
+      job_states_to_report:
+      - failure
+      - error
+      report_template: ':volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*.
+        <{{.Status.URL}}|View logs> :volcano:'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/e2e-openstack-stf-cluster-profile
+      - --target=e2e-openstack-stf-1-3
+      - --variant=nightly-4.8
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/e2e-openstack-stf-cluster-profile
+        name: cluster-profile
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-openstack-vexxhost
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build01
+  decorate: true
   extra_refs:
   - base_ref: main
     org: openshift

--- a/ci-operator/step-registry/openshift/e2e/openstack/stf/OWNERS
+++ b/ci-operator/step-registry/openshift/e2e/openstack/stf/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- openstack-approvers
+reviewers:
+- openstack-reviewers

--- a/ci-operator/step-registry/openshift/e2e/openstack/stf/openshift-e2e-openstack-stf-1-3-workflow.metadata.json
+++ b/ci-operator/step-registry/openshift/e2e/openstack/stf/openshift-e2e-openstack-stf-1-3-workflow.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openshift/e2e/openstack/stf/openshift-e2e-openstack-stf-1-3-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"openstack-approvers"
+		],
+		"reviewers": [
+			"openstack-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openshift/e2e/openstack/stf/openshift-e2e-openstack-stf-1-3-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/openstack/stf/openshift-e2e-openstack-stf-1-3-workflow.yaml
@@ -1,0 +1,16 @@
+workflow:
+  as: openshift-e2e-openstack-stf-1-3
+  steps:
+    pre:
+      - chain: ipi-openstack-pre
+    test:
+      - ref: openstack-provision-stf
+    post:
+      - chain: ipi-openstack-post
+    env:
+      BASE_DOMAIN: shiftstack.devcluster.openshift.com
+      CONFIG_TYPE: "minimal"
+  documentation: |-
+    The openshift-e2e-openstack-stf-1-3 workflow executes an installation of
+    OpenShift and then deploys Service Telemetry Framework 1.3 (STF) on top of
+    it.

--- a/ci-operator/step-registry/openstack/provision/stf/OWNERS
+++ b/ci-operator/step-registry/openstack/provision/stf/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- openstack-approvers
+reviewers:
+- openstack-reviewers

--- a/ci-operator/step-registry/openstack/provision/stf/openstack-provision-stf-1-3-commands.sh
+++ b/ci-operator/step-registry/openstack/provision/stf/openstack-provision-stf-1-3-commands.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This script will deploy STF.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# I think you'll need that
+export KUBECONFIG=${SHARED_DIR}/kubeconfig
+oc get nodes
+
+# if you need to put stuffs in a shared dir between step registry:
+echo foo > ${SHARED_DIR}/bar
+
+# if you need to collect artifacts
+echo foo > ${ARTIFACT_DIR}/bar
+
+# install ansible, run ansible, etc.

--- a/ci-operator/step-registry/openstack/provision/stf/openstack-provision-stf-1-3-ref.metadata.json
+++ b/ci-operator/step-registry/openstack/provision/stf/openstack-provision-stf-1-3-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "openstack/provision/stf/openstack-provision-stf-1-3-ref.yaml",
+	"owners": {
+		"approvers": [
+			"openstack-approvers"
+		],
+		"reviewers": [
+			"openstack-reviewers"
+		]
+	}
+}

--- a/ci-operator/step-registry/openstack/provision/stf/openstack-provision-stf-1-3-ref.yaml
+++ b/ci-operator/step-registry/openstack/provision/stf/openstack-provision-stf-1-3-ref.yaml
@@ -1,0 +1,10 @@
+ref:
+  as: openstack-provision-stf-1-3
+  from: openstack-installer
+  commands: openstack-provision-stf-1-3-commands.sh
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
+  documentation: |-
+    This step will deploy Service Telemetry Framework 1.3 (STF).


### PR DESCRIPTION
This job will deploy OpenShift on top of OpenStack, then instead of
running e2e test suite, it'll deploy Service Telemetry Framework 1.3
(STF) on top of the OCP cluster.